### PR TITLE
Add instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ cargo build --release
 cargo install glim-tui
 ```
 
+#### Arch Linux
+
+```
+pacman -S glim
+```
+
 ### Running
 
 To use glim, you'll need a GitLab personal access token (PAT) for authentication with the GitLab API.


### PR DESCRIPTION
Now available in Arch Linux :)

https://archlinux.org/packages/extra/x86_64/glim/
