### PR TITLE
Feature Request: Add gitlab_token_file option to config

### DIFF
--- a/src/glim_app.rs
+++ b/src/glim_app.rs
@@ -42,6 +42,8 @@ pub struct GlimConfig {
     pub gitlab_url: CompactString,
     /// The Personal Access Token to authenticate with GitLab
     pub gitlab_token: CompactString,
+    #[serde(default)]
+    pub gitlab_token_file: Option<PathBuf>,
     /// Filter applied to the projects list
     pub search_filter: Option<CompactString>,
     /// Logging level: Off, Error, Warn, Info, Debug, Trace
@@ -56,6 +58,7 @@ impl Default for GlimConfig {
         Self {
             gitlab_url: "https://".into(),
             gitlab_token: "".into(),
+            gitlab_token_file: None,
             search_filter: None,
             log_level: Some("Error".into()),
             animations: true,

--- a/src/ui/popup/config_popup.rs
+++ b/src/ui/popup/config_popup.rs
@@ -1,4 +1,4 @@
-use std::vec;
+use std::{path::PathBuf, vec};
 
 use compact_str::{CompactString, ToCompactString};
 use ratatui::{
@@ -164,9 +164,14 @@ impl ConfigPopupState {
             .unwrap_or(&"")
             .trim()
             .to_compact_string();
-        let search_filter_value = values.get(2).unwrap_or(&"").trim();
-        let log_level_value = values.get(3).unwrap_or(&"Off").trim();
-        let animations_value = values.get(4).unwrap_or(&"true").trim();
+        let gitlab_token_file = values
+            .get(2)
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| PathBuf::from(s));
+        let search_filter_value = values.get(3).unwrap_or(&"").trim();
+        let log_level_value = values.get(4).unwrap_or(&"Off").trim();
+        let animations_value = values.get(5).unwrap_or(&"true").trim();
 
         let search_filter = if search_filter_value.is_empty() {
             None
@@ -185,6 +190,7 @@ impl ConfigPopupState {
         GlimConfig {
             gitlab_url,
             gitlab_token,
+            gitlab_token_file,
             search_filter,
             log_level,
             animations,


### PR DESCRIPTION
This would be a better option from security point in certain scenarios.
I tried my fork and it works, but I am must say I am not rust dev and have no idea about the code stability since I used AI.

```nix
{
  config,
  pkgs,
  ...
}:
let
  glim = pkgs.rustPlatform.buildRustPackage {
    pname = "glim";
    # version = "git-cd53dae";
    # src = pkgs.fetchFromGitHub {
    #   owner = "junkdog";
    #   repo = "glim";
    #   rev = "cd53dae";
    #   hash = "sha256-yAymON+o2slcyCpEq5prkffUelW5jV3I9JSJuQc6+jc=";
    # };
    # cargoHash = "sha256-9DxUgv10cSsTlwqTJWtNxcd/hbS6pGZ+XCPjL1wbCh8=";
    version = "git-f141972";
    src = pkgs.fetchFromGitHub {
      owner = "mshnwq";
      repo = "glim";
      rev = "f1419721699e400f9ca035cfd5b4fb72c58c6410";
      hash = "sha256-vNJn2Xf8KBZMDD3hK0SXLQ9+84hDid2+NHNviU3oCGs=";
    };
    cargoHash = "sha256-9DxUgv10cSsTlwqTJWtNxcd/hbS6pGZ+XCPjL1wbCh8=";
    nativeBuildInputs = [ pkgs.pkg-config ]; # for build-time discovery
    buildInputs = [ pkgs.openssl ]; # OpenSSL headers & libs
  };
in
{
...
    ++ ([
      (pkgs.symlinkJoin {
        name = "glim";
        buildInputs = [ pkgs.makeWrapper ];
        paths = [ glim ];
        postBuild =
          let
            # glim-token = builtins.readFile config.sops.secrets."glim-token".path;
            # configFile = pkgs.writeText "glim.toml" ''
            #   gitlab_url = "https://gitlab.com/api/v4"
            #   gitlab_token = ${glim-token}
            # '';
            configFile = pkgs.writeText "glim.toml" ''
              gitlab_url = "https://gitlab.com/api/v4"
              gitlab_token = ""
              gitlab_token_file = "${config.sops.secrets."glim-token".path}"
              animations = true
            '';
          in
          ''
            wrapProgram $out/bin/glim \
              --append-flags "--config ${configFile}"
          '';
      })
    ]);
}
```